### PR TITLE
ハイフンあり、なしのValidationを分ける

### DIFF
--- a/valid.go
+++ b/valid.go
@@ -7,27 +7,27 @@ import (
 )
 
 
-var zipnreg *regexp.Regexp
-var ziphreg *regexp.Regexp
-var telnreg *regexp.Regexp
-var telhreg *regexp.Regexp
-var mailreg *regexp.Regexp
-var nbrnreg *regexp.Regexp
-var nbrfreg *regexp.Regexp
+var Zipnreg *regexp.Regexp
+var Ziphreg *regexp.Regexp
+var Telnreg *regexp.Regexp
+var Telhreg *regexp.Regexp
+var Mailreg *regexp.Regexp
+var Nbrnreg *regexp.Regexp
+var Nbrfreg *regexp.Regexp
 
 
 func init() {
 
-	zipnreg = regexp.MustCompile(`^[0-9]{7}$`)
-	ziphreg = regexp.MustCompile(`^[0-9]{3}-{1}[0-9]{4}$`)
+	Zipnreg = regexp.MustCompile(`^[0-9]{7}$`)
+	Ziphreg = regexp.MustCompile(`^[0-9]{3}-{1}[0-9]{4}$`)
 
-	telnreg = regexp.MustCompile(`^[0-9]{10,11}$`)
-	telhreg = regexp.MustCompile(`^[0-9]{3,4}-{1}[0-9]{2,4}-{1}[0-9]{4}$`)
+	Telnreg = regexp.MustCompile(`^[0-9]{10,11}$`)
+	Telhreg = regexp.MustCompile(`^[0-9]{3,4}-{1}[0-9]{2,4}-{1}[0-9]{4}$`)
 
-	mailreg = regexp.MustCompile(`^[a-zA-Z0-9_.+-]+@((?:[-a-z0-9]+\.)+[a-z]{2,})$`)
+	Mailreg = regexp.MustCompile(`^[a-zA-Z0-9_.+-]+@((?:[-a-z0-9]+\.)+[a-z]{2,})$`)
 
-	nbrnreg = regexp.MustCompile(`^[1-9]+[0-9]?$`)
-	nbrfreg = regexp.MustCompile(`^(0|[1-9]+)\.[0-9]+$`)
+	Nbrnreg = regexp.MustCompile(`^[1-9]+[0-9]?$`)
+	Nbrfreg = regexp.MustCompile(`^(0|[1-9]+)\.[0-9]+$`)
 }
 
 
@@ -51,9 +51,6 @@ func IsNotEmpty(input *interface{}) bool {
 			}
 
 	}
-
-
-
 
 	return res
 
@@ -125,38 +122,44 @@ func IsFullKana(input string,require bool) bool {
 }
 
 
-func IsTel(input string,require bool) bool {
+func IsNbrTel(input string,require bool) bool {
 
 	if !require && len(input)==0 {
 		return true
 	}
 
-	res := telnreg.MatchString(input)
-	
-	if res {
-		return true
-	}
-
-	return telhreg.MatchString(input)
+	return Telnreg.MatchString(input)
 }
 
 
-
-func IsZipcode(input string,require bool) bool {
+func IsHyphenedTel(input string,require bool) bool {
 
 	if !require && len(input)==0 {
 		return true
 	}
 
-	res := zipnreg.MatchString(input)
+	return Telhreg.MatchString(input)
+}
 
-	if res {
+
+func IsNbrZipcode(input string,require bool) bool {
+
+	if !require && len(input)==0 {
 		return true
 	}
 
-	return ziphreg.MatchString(input)
+	return  Zipnreg.MatchString(input)
 }
 
+
+func IsHyphenedZipcode(input string,require bool) bool {
+
+	if !require && len(input)==0 {
+		return true
+	}
+
+	return Ziphreg.MatchString(input)
+}
 
 
 func IsMailadr(input string,require bool) bool {
@@ -165,7 +168,7 @@ func IsMailadr(input string,require bool) bool {
 		return true
 	}
 
-	return mailreg.MatchString(input)
+	return Mailreg.MatchString(input)
 }
 
 
@@ -183,11 +186,11 @@ func IsNumeric(input string,require bool) bool {
 	p := strings.Split(input,".")
 
 	if len(p) == 1 {
-		return nbrnreg.MatchString(input)
+		return Nbrnreg.MatchString(input)
 	}
 
 	if len(p) == 2 {
-		return nbrfreg.MatchString(input)
+		return Nbrfreg.MatchString(input)
 	}
 
 	return false

--- a/valid_test.go
+++ b/valid_test.go
@@ -111,7 +111,7 @@ func TestIsFullKana(t *testing.T) {
 }
 
 
-func TestIsTel(t *testing.T) {
+func TestIsNbrTel(t *testing.T) {
 
 	type Input struct {
 		Str string
@@ -121,9 +121,47 @@ func TestIsTel(t *testing.T) {
 
 	tests := []Input{
 		Input{"",false,true},
+		Input{"",true,false},
+		Input{"0251234567",false,true},
 		Input{"0251234567",true,true},
-		Input{"025-123-4567",true,true},
+		Input{"025-123-4567",true,false},
+		Input{"025-123-4567",false,false},
 		Input{"08011223344",true,true},
+		Input{"080-1122-3344",true,false},
+		Input{"0255-12-3456",true,false},
+		Input{"025-121-345",true,false},
+		Input{"02-1211-3451",true,false},
+		Input{"0244-121-34511",true,false},
+		Input{"a24-1222-1111",true,false},
+	}
+
+	for _,tt := range tests {
+
+		result := IsNbrTel(tt.Str,tt.Req)
+
+		if result != tt.Expect {
+			t.Error(fmt.Sprintf("Error %s 実際：%v  理想：%v \n",tt.Str,result,tt.Expect))
+		} 
+	}
+}
+
+
+func TestIsHyphenedTel(t *testing.T) {
+
+	type Input struct {
+		Str string
+		Req bool
+		Expect bool
+	}
+
+	tests := []Input{
+		Input{"",false,true},
+		Input{"",true,false},
+		Input{"0251234567",true,false},
+		Input{"0251234567",false,false},
+		Input{"025-123-4567",true,true},
+		Input{"025-123-4567",false,true},
+		Input{"08011223344",true,false},
 		Input{"080-1122-3344",true,true},
 		Input{"0255-12-3456",true,true},
 		Input{"025-121-345",true,false},
@@ -134,7 +172,7 @@ func TestIsTel(t *testing.T) {
 
 	for _,tt := range tests {
 
-		result := IsTel(tt.Str,tt.Req)
+		result := IsHyphenedTel(tt.Str,tt.Req)
 
 		if result != tt.Expect {
 			t.Error(fmt.Sprintf("Error %s 実際：%v  理想：%v \n",tt.Str,result,tt.Expect))
@@ -142,7 +180,8 @@ func TestIsTel(t *testing.T) {
 	}
 }
 
-func TestIsZipcode(t *testing.T) {
+
+func TestIsNbrZipcode(t *testing.T) {
 
 	type Input struct {
 		Str string
@@ -152,15 +191,48 @@ func TestIsZipcode(t *testing.T) {
 
 	tests := []Input{
 		Input{"",false,true},
+		Input{"",true,false},
 		Input{"9501122",true,true},
-		Input{"950-1122",true,true},
+		Input{"9501122",false,true},
+		Input{"950-1122",true,false},
+		Input{"950-1122",false,false},
 		Input{"95-11122",true,false},
 		Input{"950a1122",true,false},
 	}
 
 	for _,tt := range tests {
 
-		result := IsZipcode(tt.Str,tt.Req)
+		result := IsNbrZipcode(tt.Str,tt.Req)
+
+		if result != tt.Expect {
+			t.Error(fmt.Sprintf("Error %s 実際：%v  理想：%v \n",tt.Str,result,tt.Expect))
+		} 
+	}
+}
+
+
+func TestIsHyphenedZipcode(t *testing.T) {
+
+	type Input struct {
+		Str string
+		Req bool
+		Expect bool
+	}
+
+	tests := []Input{
+		Input{"",false,true},
+		Input{"",true,false},
+		Input{"9501122",true,false},
+		Input{"9501122",false,false},
+		Input{"950-1122",true,true},
+		Input{"950-1122",false,true},
+		Input{"95-11122",true,false},
+		Input{"950a1122",true,false},
+	}
+
+	for _,tt := range tests {
+
+		result := IsHyphenedZipcode(tt.Str,tt.Req)
 
 		if result != tt.Expect {
 			t.Error(fmt.Sprintf("Error %s 実際：%v  理想：%v \n",tt.Str,result,tt.Expect))


### PR DESCRIPTION
Closes #1 

### valid.go
- regexp.Regexpをパッケージ外から利用可能に
- 郵便番号のハイフンあり、なしValidaton対応
- 電話番号のハイフンあり、なしValidaton対応
- これらのテスト
