### PR TITLE
カナのValidationで「ー」をOKにする

### DIFF
--- a/valid.go
+++ b/valid.go
@@ -111,10 +111,8 @@ func IsFullKana(input string,require bool) bool {
 	b := true 
 
 	for _,x := range xx {
-		if x < 0x30A1 || 0x30F6 < x {
-			// fmt.Printf("%d %d %c %x \n",i,x,x,x)
-			b=false
-			// return false
+		if (x < 0x30A1 || 0x30F6 < x) && (x != 0x30fc) {
+			b =false
 		}
 	} 
 

--- a/valid_test.go
+++ b/valid_test.go
@@ -94,7 +94,7 @@ func TestIsFullKana(t *testing.T) {
 	tests := []Input{
 		Input{"",false,true},
 		Input{"やまだたろう",true,false},
-		Input{"カタカナ",true,true},
+		Input{"カタカーナ",true,true},
 		Input{"aaa,",true,false},
 		Input{"'bbb",true,false},
 		Input{"ｶﾀｶﾅ",true,false},


### PR DESCRIPTION
カナの判定はー（0x30fc）をOKにする

Closes #3